### PR TITLE
chore(lp): fix compilation error

### DIFF
--- a/src/util/lp/permutation_matrix.h
+++ b/src/util/lp/permutation_matrix.h
@@ -123,7 +123,7 @@ namespace lean {
 
         unsigned size() const { return static_cast<unsigned>(m_rev.size()); }
 
-        unsigned * values() const { return m_permutation; }
+        const unsigned * values() const { return &m_permutation[0]; }
     }; // end of the permutation class
 
 #ifdef LEAN_DEBUG


### PR DESCRIPTION
```
/build/source/src/util/lp/permutation_matrix.h:126:44: error: cannot convert 'const std::vector<unsigned int>' to 'unsigned int*' in return
  126 |         unsigned * values() const { return m_permutation; }
      |                                            ^~~~~~~~~~~~~
      |                                            |
      |                                            const std::vector<unsigned int>
```

(cc @fpvandoorn, who I think was the last to maintain lean2)